### PR TITLE
new feature update - trigger_handler.js 0.1.1v

### DIFF
--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -5,11 +5,13 @@
   @issue
     + TE 트리거 코드 출력 기능
      개발된 기능들
-      - 총 폭탄 수 한번에 터지는 폭탄 수 관계 없이 트리거 출력 가능
+      - 
+      - 한번에 터지는 폭탄 수 관계 없이 출력 가능
       - TE 상수, TETextCreator의 함수로 TE용 트리거 텍스트 코드 변환
      추가할 내용
       - 폭탄 터지는 옵션 처리
       - 장애물 처리
+      - 64개가 넘어가는 트리거 세트 처리
       - TE 상수 추가 지속
       - TETextCreator 함수 추가 지속
 */
@@ -53,7 +55,7 @@ function getPatternTETriggerText(pattern) {
     
     if (locationListLength == 0 || (turnList.length == 1 && turnList[0].cellList.length == 0)) {
         /* 로케이션이나 폭탄이 없으면 트리거를 작성하지 않는다. */
-        return null;
+        return "";
     }
     
     // 폭탄 갯수를 파악해서 미리 트리거를 어떻게 나눌지 파악할 수 있을까?

--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -1,23 +1,17 @@
 /*
- * @ name: trigger_handler.js
- * @ version: 0.1.1
- * @ author: joshow
- * @ brief: 폭탄피하기 패턴을 특정 포맷에 맞는 트리거 코드로 변환한다.
- * @ detail
- *   trigger_handler.js는 BoundEditorLS에서 취급하는 BoundPattern 객체를 특정 포맷에 맞는 트리거 코드로 변환시킨다.
- *   SCM Draft 2의 플러그인인 'TE'와 'TE+' 포맷에 맞는 텍스트 코드 변환과 '.scx' 같은 스타크래프트 맵 파일에 직접 트리거 바이너리 코드를 삽입하는 기능 구현까지 목표로 하고 있다.
- *   추가로 BoundEditorLS 내에서 패턴 외의 간단한 트리거 편집 기능 추가도 고려하고 있다.
- *   
- *   0.1.1v - 2020.03.18
- *    - 0.1.1v 은 TE 트리거 변환만 지원한다.
- *    - getPatternTETriggerText()를 호출하여 BoundPattern 객체를 TE 트리거 코드로(String) 반환한다.
- *    - TE 에서 취급하는 문자열 상수들이 정의되어 있다.
- *    - TETextCreator 객체를 통해 TE 트리거 함수를 호출하듯 트리거 코드를 작성할 수 있다.
- *    - TE 함수를 호출할 때는 아래와 같은 순서대로 작성해야 올바른 트리거 코드를 얻을 수 있다.
-        < Trigger() - Conditions() - {조건들} - Actions() - {액션들} - TriggerEnd() > 
- *    - 또한 conditionLineCount와 actionLineCount가 최대치를 넘지 않도록 유의하여 작성하여야 한다.
- *    - 0.1.1v 에서는 구현하면서 꼭 필요했던 상수들과 함수들만 추가하였으나 그 외의 것이 필요하다면 TE와 동일한 양식으로 추가하면 된다.
- *    - 기본 기능 테스트는 전부 마쳤지만 그 외 많은 테스트를 수행하지 못했기에 문제가 발생할 여지가 있다.
+  @file: trigger_handler.js
+  @author: joshow
+  @brief: 패턴을 양식에 맞는 Trigger 코드로 변환한다.(텍스트 or 바이트 코드)
+  @issue
+    + TE 트리거 코드 출력 기능
+     개발된 기능들
+      - 총 폭탄 수 한번에 터지는 폭탄 수 관계 없이 트리거 출력 가능
+      - TE 상수, TETextCreator의 함수로 TE용 트리거 텍스트 코드 변환
+     추가할 내용
+      - 폭탄 터지는 옵션 처리
+      - 장애물 처리
+      - TE 상수 추가 지속
+      - TETextCreator 함수 추가 지속
 */
 
 const TE_QUANTITYMOD_AT_MOST = "At most";
@@ -28,7 +22,7 @@ const TE_RESOURCE_ORE = "ore";
 const TE_RESOURCE_GAS = "gas";
 const TE_RESOURCE_ORE_AND_GAS = "ore and gas";
 
-const TE_SWITCHSTATUS_CLEARED = "not set";
+const TE_SWITCHSTATUS_CLEARED = "cleared";
 const TE_SWITCHSTATUS_SET = "set";
 
 const TE_PLAYER_P1 = "Player 1";
@@ -41,22 +35,17 @@ const TE_PLAYER_P7 = "Player 7";
 const TE_PLAYER_P8 = "Player 8";
 const TE_PLAYER_ALL = "All Players";
 const TE_PLAYER_CURRENT = "Current Player";
+const TE_PLAYER_FORCE1 = "Force 1";
+const TE_PLAYER_FORCE2 = "Force 2";
+const TE_PLAYER_FORCE3 = "Force 3";
+const TE_PLAYER_FORCE4 = "Force 4";
 
 const TE_UNIT_MEN = "Men";
 const TE_UNIT_FACTORIES = "Factories";
 const TE_UNIT_BUILDINGS = "Buildings";
 const TE_UNIT_ANY_UNIT = "Any unit";
 
-const TE_ALL = "All"; // 갯수 셀 때 전부를 의미
-
-const TE_STATE_DISABLE = "disabled";
-const TE_STATE_ENABLE = "enabled";
-const TE_STATE_TOGGLE = "toggle";
-
-const TE_MODIFY_ADD = "Add";
-const TE_MODIFY_SET_TO = "Set To";
-const TE_MODIFY_SUBTRACT = "Subtract";
-
+const TE_ALL = "All";
 
 function getPatternTETriggerText(pattern) {
     var locationListLength = pattern.locationList.length;
@@ -91,42 +80,21 @@ function getPatternTETriggerText(pattern) {
 
     triggerText += creator.Actions();
     
+    var lineCount = 0;
     turnList.forEach(function(turn, i, turns) {
         
         for (var cell of turn.cellList) {
-            // type - 1 : 폭탄 Cell, 2 : 장애물 생성 Cell, 3 : 장애물 삭제 Cell
-            // option - 1 : 유닛 Kill, 2 : 유닛 Remove, 3 : 유닛 생존, 4 : 장애물 Kill, 5: 장애물 Remove
-            // option은 type 2,3 일 때만 의미를 가지며 type 1일 때의 값은 0 이다.
-            // Remove와 kill 순서가 꼬여서 문제가 발생 가능성 있음. 일단 다 작성하고 확인
-            if (cell.type == 1) { 
-                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
-                triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
-            }
-            else if (cell.type == 2) {
-                if (cell.option == 1)
-                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
-                else if (cell.option == 2)
-                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
-                
-                // 장애물 생성
-                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
-                
-            }
-            else if (cell.type == 3) {
-                if (cell.option == 4)
-                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
-                else (cell.option == 5)
-                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
-            }
-            else console.error("Unknown type BoundTurncell");
+            triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
+            triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+            lineCount += 2;
             
-            if (creator.actionLineCount > 60) {
+            if (lineCount > 60) {
                 triggerConditionCount++;
                 triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);    
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
-
+                lineCount = 0;
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -138,15 +106,17 @@ function getPatternTETriggerText(pattern) {
             }
         }
         triggerText += creator.Wait(turn.wait);
+        lineCount += 1;
         
         /* 더 출력할 액션이 있는지 확인하고 있다면 새 트리거 폼을 만든다 */
         if (i + 1 < turns.length) {
-            if ((creator.actionLineCount + turns[i + 1].cellList.length * 2) > 60) { 
+            if ((lineCount + turns[i + 1].cellList.length * 2) > 60) { 
                 triggerConditionCount++;
-                triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, triggerConditionCount, TE_RESOURCE_ORE);
+                triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
+                lineCount = 0;
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -159,7 +129,7 @@ function getPatternTETriggerText(pattern) {
     });
     
     if (triggerConditionCount > 1) {
-        triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, 1, TE_RESOURCE_ORE);
+        triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", 1, TE_RESOURCE_ORE);
     }
     
     triggerText += creator.PreserveTrigger();
@@ -171,13 +141,9 @@ function getPatternTETriggerText(pattern) {
 
 
 var TETextCreator = function() {
-    this.conditionLineCount = 0;
-    this.actionLineCount = 0;
     
     /*** TRIGGER ***/
     this.Trigger = function(player) {
-        this.conditionLineCount = 0;
-        this.actionLineCount = 0;
         // '{' 를 열기 떄문에 사용 후 TriggerEnd()로 끝나야함
         return "Trigger(\"" + player + "\"){\n";
     }
@@ -197,60 +163,35 @@ var TETextCreator = function() {
     
     /*** Conditions ***/
     this.Switch = function(num) {
-        this.conditionLineCount++;
         return "\tSwitch(\"Switch" + num + "\", set);\n";
     }
     
     this.Accumulate = function(player, quantitymod, quantitynum, resource) {
-        this.conditionLineCount
         return "\tAccumulate(\"" + player + "\", " + quantitymod + ", " + quantitynum + ", " + resource + ");\n";
     }
     
     /*** Actions ***/
     this.CreateUnitWithProperties = function(player, unit, num, location, properties) {
-        /* properties
-         * TE+와 달리 그냥 TE는 Properties에 대한 명확한 명시가 제대로 안되어 있음.
-         * 따라서 필요에 따라 직접 확인하거나 아래 명시된 수치를 사용할 것
-         * 3 - Invicible
-         * 4 - Invicible & Hallucinated
-         * 5 - Hallucinated
-        */
-        this.actionLineCount++;
         return "\tCreate Unit with Properties(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\", " + properties + ");\n"; // 마지막 숫자 매개변수가 유닛의 상태이다.
     }
     
     this.CreateBomb = function(player, unit, location) {
-        /* CreateBomb()은 무적 상태 유닛을 1기를 생산한다. */
-        return this.CreateUnitWithProperties(player, unit, 1, location, 3);
+        return this.CreateUnitWithProperties(player, unit, 1, location, 1);
     }
 
     this.KillUnitAtLocation = function(player, unit, num, location) {
-        this.actionLineCount++;
         return "\tKill Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
     }
     
     this.PreserveTrigger = function() {
-        this.actionLineCount++;
         return "\tPreserve Trigger();\n";
     }
-    
-    this.RemoveUnitAtLocation = function(player, unit, num, location) {
-        this.actionLineCount++;
-        return "\tRemove Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
-    }
-    /*
-    this.SetInvincibility = function(player, unit, location, state) {
-        this.actionLineCount++;
-        return "\tSet Invincibility(\"" + player + "\", \"" + unit + "\", \"" + location + "\", " + state + ");\n";
-    }
-    */
-    this.SetResources = function(player, modify, num, resource) {
-        this.actionLineCount++;
-        return "\tSet Resources(\"" + player + "\", " + modify + ", " + num + ", " + resource + ");\n";
+    /* setto 변수명 맵 에디터에서 확인 후 변경할 것 */
+    this.SetResources = function(player, setto, num, resource) {
+        return "\tSet Resources(\"" + player + "\", " + setto + ", " + num + ", " + resource + ");\n";
     }
     
     this.Wait = function(duration) {
-        this.actionLineCount++;
         return "\tWait(" + duration + ");\n";
     }
 }

--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -1,19 +1,24 @@
 /*
-  @file: trigger_handler.js
-  @author: joshow
-  @brief: 패턴을 양식에 맞는 Trigger 코드로 변환한다.(텍스트 or 바이트 코드)
-  @issue
-    + TE 트리거 코드 출력 기능
-     개발된 기능들
-      - 
-      - 한번에 터지는 폭탄 수 관계 없이 출력 가능
-      - TE 상수, TETextCreator의 함수로 TE용 트리거 텍스트 코드 변환
-     추가할 내용
-      - 폭탄 터지는 옵션 처리
-      - 장애물 처리
-      - 64개가 넘어가는 트리거 세트 처리
-      - TE 상수 추가 지속
-      - TETextCreator 함수 추가 지속
+ * @ name: trigger_handler.js
+ * @ version: 0.1.1
+ * @ author: joshow
+ * @ brief: 폭탄피하기 패턴을 특정 포맷에 맞는 트리거 코드로 변환한다.
+ * @ detail
+ *   trigger_handler.js는 BoundEditorLS에서 취급하는 BoundPattern 객체를 특정 포맷에 맞는 트리거 코드로 변환시킨다.
+ *   SCM Draft 2의 플러그인인 'TE'와 'TE+' 포맷에 맞는 텍스트 코드 변환과 '.scx' 같은 스타크래프트 맵 파일에 직접 트리거 바이너리 코드를 삽입하는 기능 구현까지 목표로 하고 있다.
+ *   추가로 BoundEditorLS 내에서 패턴 외의 간단한 트리거 편집 기능 추가도 고려하고 있다.
+ *   
+ *   0.1.1v - 2020.03.18
+ *    - 0.1.1v 은 TE 트리거 변환만 지원한다.
+ *    - getPatternTETriggerText()를 호출하여 BoundPattern 객체를 TE 트리거 코드로(String) 반환한다.
+ *    - 플레이어는 Player7, 조건은  Switch15와 1 이상의 미네랄로 고정되어있다. 차후 수정될 예정이다.
+ *    - TE 에서 취급하는 문자열 상수들이 정의되어 있다.
+ *    - TETextCreator 객체를 통해 TE 트리거 함수를 호출하듯 트리거 코드를 작성할 수 있다.
+ *    - TE 함수를 호출할 때는 아래와 같은 순서대로 작성해야 올바른 트리거 코드를 얻을 수 있다.
+        < Trigger() - Conditions() - {조건들} - Actions() - {액션들} - TriggerEnd() > 
+ *    - 또한 conditionLineCount와 actionLineCount가 최대치를 넘지 않도록 유의하여 작성하여야 한다.
+ *    - 0.1.1v 에서는 구현하면서 꼭 필요했던 상수들과 함수들만 추가하였으나 그 외의 것이 필요하다면 TE와 동일한 양식으로 추가하면 된다.
+ *    - 기본 기능 테스트는 전부 마쳤지만 그 외 많은 테스트를 수행하지 못했기에 문제가 발생할 여지가 있다.
 */
 
 const TE_QUANTITYMOD_AT_MOST = "At most";
@@ -24,7 +29,7 @@ const TE_RESOURCE_ORE = "ore";
 const TE_RESOURCE_GAS = "gas";
 const TE_RESOURCE_ORE_AND_GAS = "ore and gas";
 
-const TE_SWITCHSTATUS_CLEARED = "cleared";
+const TE_SWITCHSTATUS_CLEARED = "not set";
 const TE_SWITCHSTATUS_SET = "set";
 
 const TE_PLAYER_P1 = "Player 1";
@@ -37,17 +42,22 @@ const TE_PLAYER_P7 = "Player 7";
 const TE_PLAYER_P8 = "Player 8";
 const TE_PLAYER_ALL = "All Players";
 const TE_PLAYER_CURRENT = "Current Player";
-const TE_PLAYER_FORCE1 = "Force 1";
-const TE_PLAYER_FORCE2 = "Force 2";
-const TE_PLAYER_FORCE3 = "Force 3";
-const TE_PLAYER_FORCE4 = "Force 4";
 
 const TE_UNIT_MEN = "Men";
 const TE_UNIT_FACTORIES = "Factories";
 const TE_UNIT_BUILDINGS = "Buildings";
 const TE_UNIT_ANY_UNIT = "Any unit";
 
-const TE_ALL = "All";
+const TE_ALL = "All"; // 갯수 셀 때 전부를 의미
+
+const TE_STATE_DISABLE = "disabled";
+const TE_STATE_ENABLE = "enabled";
+const TE_STATE_TOGGLE = "toggle";
+
+const TE_MODIFY_ADD = "Add";
+const TE_MODIFY_SET_TO = "Set To";
+const TE_MODIFY_SUBTRACT = "Subtract";
+
 
 function getPatternTETriggerText(pattern) {
     var locationListLength = pattern.locationList.length;
@@ -55,7 +65,7 @@ function getPatternTETriggerText(pattern) {
     
     if (locationListLength == 0 || (turnList.length == 1 && turnList[0].cellList.length == 0)) {
         /* 로케이션이나 폭탄이 없으면 트리거를 작성하지 않는다. */
-        return "";
+        return null;
     }
     
     // 폭탄 갯수를 파악해서 미리 트리거를 어떻게 나눌지 파악할 수 있을까?
@@ -82,21 +92,42 @@ function getPatternTETriggerText(pattern) {
 
     triggerText += creator.Actions();
     
-    var lineCount = 0;
     turnList.forEach(function(turn, i, turns) {
         
         for (var cell of turn.cellList) {
-            triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
-            triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
-            lineCount += 2;
+            // type - 1 : 폭탄 Cell, 2 : 장애물 생성 Cell, 3 : 장애물 삭제 Cell
+            // option - 1 : 유닛 Kill, 2 : 유닛 Remove, 3 : 유닛 생존, 4 : 장애물 Kill, 5: 장애물 Remove
+            // option은 type 2,3 일 때만 의미를 가지며 type 1일 때의 값은 0 이다.
+            // Remove와 kill 순서가 꼬여서 문제가 발생 가능성 있음. 일단 다 작성하고 확인
+            if (cell.type == 1) { 
+                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
+                triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+            }
+            else if (cell.type == 2) {
+                if (cell.option == 1)
+                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+                else if (cell.option == 2)
+                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+                
+                // 장애물 생성
+                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
+                
+            }
+            else if (cell.type == 3) {
+                if (cell.option == 4)
+                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
+                else if (cell.option == 5)
+                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
+            }
+            else console.error("Unknown type BoundTurncell");
             
-            if (lineCount > 60) {
+            if (creator.actionLineCount > 60) {
                 triggerConditionCount++;
                 triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);    
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
-                lineCount = 0;
+
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -108,17 +139,15 @@ function getPatternTETriggerText(pattern) {
             }
         }
         triggerText += creator.Wait(turn.wait);
-        lineCount += 1;
         
         /* 더 출력할 액션이 있는지 확인하고 있다면 새 트리거 폼을 만든다 */
         if (i + 1 < turns.length) {
-            if ((lineCount + turns[i + 1].cellList.length * 2) > 60) { 
+            if ((creator.actionLineCount + turns[i + 1].cellList.length * 2) > 60) { 
                 triggerConditionCount++;
-                triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);
+                triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, triggerConditionCount, TE_RESOURCE_ORE);
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
-                lineCount = 0;
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -131,7 +160,7 @@ function getPatternTETriggerText(pattern) {
     });
     
     if (triggerConditionCount > 1) {
-        triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", 1, TE_RESOURCE_ORE);
+        triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, 1, TE_RESOURCE_ORE);
     }
     
     triggerText += creator.PreserveTrigger();
@@ -143,9 +172,13 @@ function getPatternTETriggerText(pattern) {
 
 
 var TETextCreator = function() {
+    this.conditionLineCount = 0;
+    this.actionLineCount = 0;
     
     /*** TRIGGER ***/
     this.Trigger = function(player) {
+        this.conditionLineCount = 0;
+        this.actionLineCount = 0;
         // '{' 를 열기 떄문에 사용 후 TriggerEnd()로 끝나야함
         return "Trigger(\"" + player + "\"){\n";
     }
@@ -165,35 +198,60 @@ var TETextCreator = function() {
     
     /*** Conditions ***/
     this.Switch = function(num) {
+        this.conditionLineCount++;
         return "\tSwitch(\"Switch" + num + "\", set);\n";
     }
     
     this.Accumulate = function(player, quantitymod, quantitynum, resource) {
+        this.conditionLineCount
         return "\tAccumulate(\"" + player + "\", " + quantitymod + ", " + quantitynum + ", " + resource + ");\n";
     }
     
     /*** Actions ***/
     this.CreateUnitWithProperties = function(player, unit, num, location, properties) {
+        /* properties
+         * TE+와 달리 그냥 TE는 Properties에 대한 명확한 명시가 제대로 안되어 있음.
+         * 따라서 필요에 따라 직접 확인하거나 아래 명시된 수치를 사용할 것
+         * 3 - Invicible
+         * 4 - Invicible & Hallucinated
+         * 5 - Hallucinated
+        */
+        this.actionLineCount++;
         return "\tCreate Unit with Properties(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\", " + properties + ");\n"; // 마지막 숫자 매개변수가 유닛의 상태이다.
     }
     
     this.CreateBomb = function(player, unit, location) {
-        return this.CreateUnitWithProperties(player, unit, 1, location, 1);
+        /* CreateBomb()은 무적 상태 유닛을 1기를 생산한다. */
+        return this.CreateUnitWithProperties(player, unit, 1, location, 3);
     }
 
     this.KillUnitAtLocation = function(player, unit, num, location) {
+        this.actionLineCount++;
         return "\tKill Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
     }
     
     this.PreserveTrigger = function() {
+        this.actionLineCount++;
         return "\tPreserve Trigger();\n";
     }
-    /* setto 변수명 맵 에디터에서 확인 후 변경할 것 */
-    this.SetResources = function(player, setto, num, resource) {
-        return "\tSet Resources(\"" + player + "\", " + setto + ", " + num + ", " + resource + ");\n";
+    
+    this.RemoveUnitAtLocation = function(player, unit, num, location) {
+        this.actionLineCount++;
+        return "\tRemove Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
+    }
+    /*
+    this.SetInvincibility = function(player, unit, location, state) {
+        this.actionLineCount++;
+        return "\tSet Invincibility(\"" + player + "\", \"" + unit + "\", \"" + location + "\", " + state + ");\n";
+    }
+    */
+    this.SetResources = function(player, modify, num, resource) {
+        this.actionLineCount++;
+        return "\tSet Resources(\"" + player + "\", " + modify + ", " + num + ", " + resource + ");\n";
     }
     
     this.Wait = function(duration) {
+        this.actionLineCount++;
         return "\tWait(" + duration + ");\n";
     }
 }

--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -1,17 +1,23 @@
 /*
-  @file: trigger_handler.js
-  @author: joshow
-  @brief: 패턴을 양식에 맞는 Trigger 코드로 변환한다.(텍스트 or 바이트 코드)
-  @issue
-    + TE 트리거 코드 출력 기능
-     개발된 기능들
-      - 총 폭탄 수 한번에 터지는 폭탄 수 관계 없이 트리거 출력 가능
-      - TE 상수, TETextCreator의 함수로 TE용 트리거 텍스트 코드 변환
-     추가할 내용
-      - 폭탄 터지는 옵션 처리
-      - 장애물 처리
-      - TE 상수 추가 지속
-      - TETextCreator 함수 추가 지속
+ * @ name: trigger_handler.js
+ * @ version: 0.1.1
+ * @ author: joshow
+ * @ brief: 폭탄피하기 패턴을 특정 포맷에 맞는 트리거 코드로 변환한다.
+ * @ detail
+ *   trigger_handler.js는 BoundEditorLS에서 취급하는 BoundPattern 객체를 특정 포맷에 맞는 트리거 코드로 변환시킨다.
+ *   SCM Draft 2의 플러그인인 'TE'와 'TE+' 포맷에 맞는 텍스트 코드 변환과 '.scx' 같은 스타크래프트 맵 파일에 직접 트리거 바이너리 코드를 삽입하는 기능 구현까지 목표로 하고 있다.
+ *   추가로 BoundEditorLS 내에서 패턴 외의 간단한 트리거 편집 기능 추가도 고려하고 있다.
+ *   
+ *   0.1.1v - 2020.03.18
+ *    - 0.1.1v 은 TE 트리거 변환만 지원한다.
+ *    - getPatternTETriggerText()를 호출하여 BoundPattern 객체를 TE 트리거 코드로(String) 반환한다.
+ *    - TE 에서 취급하는 문자열 상수들이 정의되어 있다.
+ *    - TETextCreator 객체를 통해 TE 트리거 함수를 호출하듯 트리거 코드를 작성할 수 있다.
+ *    - TE 함수를 호출할 때는 아래와 같은 순서대로 작성해야 올바른 트리거 코드를 얻을 수 있다.
+        < Trigger() - Conditions() - {조건들} - Actions() - {액션들} - TriggerEnd() > 
+ *    - 또한 conditionLineCount와 actionLineCount가 최대치를 넘지 않도록 유의하여 작성하여야 한다.
+ *    - 0.1.1v 에서는 구현하면서 꼭 필요했던 상수들과 함수들만 추가하였으나 그 외의 것이 필요하다면 TE와 동일한 양식으로 추가하면 된다.
+ *    - 기본 기능 테스트는 전부 마쳤지만 그 외 많은 테스트를 수행하지 못했기에 문제가 발생할 여지가 있다.
 */
 
 const TE_QUANTITYMOD_AT_MOST = "At most";
@@ -22,7 +28,7 @@ const TE_RESOURCE_ORE = "ore";
 const TE_RESOURCE_GAS = "gas";
 const TE_RESOURCE_ORE_AND_GAS = "ore and gas";
 
-const TE_SWITCHSTATUS_CLEARED = "cleared";
+const TE_SWITCHSTATUS_CLEARED = "not set";
 const TE_SWITCHSTATUS_SET = "set";
 
 const TE_PLAYER_P1 = "Player 1";
@@ -35,17 +41,22 @@ const TE_PLAYER_P7 = "Player 7";
 const TE_PLAYER_P8 = "Player 8";
 const TE_PLAYER_ALL = "All Players";
 const TE_PLAYER_CURRENT = "Current Player";
-const TE_PLAYER_FORCE1 = "Force 1";
-const TE_PLAYER_FORCE2 = "Force 2";
-const TE_PLAYER_FORCE3 = "Force 3";
-const TE_PLAYER_FORCE4 = "Force 4";
 
 const TE_UNIT_MEN = "Men";
 const TE_UNIT_FACTORIES = "Factories";
 const TE_UNIT_BUILDINGS = "Buildings";
 const TE_UNIT_ANY_UNIT = "Any unit";
 
-const TE_ALL = "All";
+const TE_ALL = "All"; // 갯수 셀 때 전부를 의미
+
+const TE_STATE_DISABLE = "disabled";
+const TE_STATE_ENABLE = "enabled";
+const TE_STATE_TOGGLE = "toggle";
+
+const TE_MODIFY_ADD = "Add";
+const TE_MODIFY_SET_TO = "Set To";
+const TE_MODIFY_SUBTRACT = "Subtract";
+
 
 function getPatternTETriggerText(pattern) {
     var locationListLength = pattern.locationList.length;
@@ -80,21 +91,42 @@ function getPatternTETriggerText(pattern) {
 
     triggerText += creator.Actions();
     
-    var lineCount = 0;
     turnList.forEach(function(turn, i, turns) {
         
         for (var cell of turn.cellList) {
-            triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
-            triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
-            lineCount += 2;
+            // type - 1 : 폭탄 Cell, 2 : 장애물 생성 Cell, 3 : 장애물 삭제 Cell
+            // option - 1 : 유닛 Kill, 2 : 유닛 Remove, 3 : 유닛 생존, 4 : 장애물 Kill, 5: 장애물 Remove
+            // option은 type 2,3 일 때만 의미를 가지며 type 1일 때의 값은 0 이다.
+            // Remove와 kill 순서가 꼬여서 문제가 발생 가능성 있음. 일단 다 작성하고 확인
+            if (cell.type == 1) { 
+                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
+                triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+            }
+            else if (cell.type == 2) {
+                if (cell.option == 1)
+                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+                else if (cell.option == 2)
+                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, TE_UNIT_MEN, TE_ALL, cell.location.label);
+                
+                // 장애물 생성
+                triggerText += creator.CreateBomb(TE_PLAYER_P7, cell.unit, cell.location.label);
+                
+            }
+            else if (cell.type == 3) {
+                if (cell.option == 4)
+                    triggerText += creator.KillUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
+                else (cell.option == 5)
+                    triggerText += creator.RemoveUnitAtLocation(TE_PLAYER_ALL, cell.unit, 1, cell.location.label);
+            }
+            else console.error("Unknown type BoundTurncell");
             
-            if (lineCount > 60) {
+            if (creator.actionLineCount > 60) {
                 triggerConditionCount++;
                 triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);    
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
-                lineCount = 0;
+
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -106,17 +138,15 @@ function getPatternTETriggerText(pattern) {
             }
         }
         triggerText += creator.Wait(turn.wait);
-        lineCount += 1;
         
         /* 더 출력할 액션이 있는지 확인하고 있다면 새 트리거 폼을 만든다 */
         if (i + 1 < turns.length) {
-            if ((lineCount + turns[i + 1].cellList.length * 2) > 60) { 
+            if ((creator.actionLineCount + turns[i + 1].cellList.length * 2) > 60) { 
                 triggerConditionCount++;
-                triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", triggerConditionCount, TE_RESOURCE_ORE);
+                triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, triggerConditionCount, TE_RESOURCE_ORE);
                 triggerText += creator.PreserveTrigger();
     				    triggerText += creator.TriggerEnd();
                 
-                lineCount = 0;
                 triggerText += creator.Trigger(TE_PLAYER_P7);
 				        triggerText += creator.Conditions();
 			    	    triggerText += creator.Switch(15, TE_SWITCHSTATUS_SET);
@@ -129,7 +159,7 @@ function getPatternTETriggerText(pattern) {
     });
     
     if (triggerConditionCount > 1) {
-        triggerText += creator.SetResources(TE_PLAYER_P7, "Set To", 1, TE_RESOURCE_ORE);
+        triggerText += creator.SetResources(TE_PLAYER_P7, TE_MODIFY_SET_TO, 1, TE_RESOURCE_ORE);
     }
     
     triggerText += creator.PreserveTrigger();
@@ -141,9 +171,13 @@ function getPatternTETriggerText(pattern) {
 
 
 var TETextCreator = function() {
+    this.conditionLineCount = 0;
+    this.actionLineCount = 0;
     
     /*** TRIGGER ***/
     this.Trigger = function(player) {
+        this.conditionLineCount = 0;
+        this.actionLineCount = 0;
         // '{' 를 열기 떄문에 사용 후 TriggerEnd()로 끝나야함
         return "Trigger(\"" + player + "\"){\n";
     }
@@ -163,35 +197,60 @@ var TETextCreator = function() {
     
     /*** Conditions ***/
     this.Switch = function(num) {
+        this.conditionLineCount++;
         return "\tSwitch(\"Switch" + num + "\", set);\n";
     }
     
     this.Accumulate = function(player, quantitymod, quantitynum, resource) {
+        this.conditionLineCount
         return "\tAccumulate(\"" + player + "\", " + quantitymod + ", " + quantitynum + ", " + resource + ");\n";
     }
     
     /*** Actions ***/
     this.CreateUnitWithProperties = function(player, unit, num, location, properties) {
+        /* properties
+         * TE+와 달리 그냥 TE는 Properties에 대한 명확한 명시가 제대로 안되어 있음.
+         * 따라서 필요에 따라 직접 확인하거나 아래 명시된 수치를 사용할 것
+         * 3 - Invicible
+         * 4 - Invicible & Hallucinated
+         * 5 - Hallucinated
+        */
+        this.actionLineCount++;
         return "\tCreate Unit with Properties(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\", " + properties + ");\n"; // 마지막 숫자 매개변수가 유닛의 상태이다.
     }
     
     this.CreateBomb = function(player, unit, location) {
-        return this.CreateUnitWithProperties(player, unit, 1, location, 1);
+        /* CreateBomb()은 무적 상태 유닛을 1기를 생산한다. */
+        return this.CreateUnitWithProperties(player, unit, 1, location, 3);
     }
 
     this.KillUnitAtLocation = function(player, unit, num, location) {
+        this.actionLineCount++;
         return "\tKill Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
     }
     
     this.PreserveTrigger = function() {
+        this.actionLineCount++;
         return "\tPreserve Trigger();\n";
     }
-    /* setto 변수명 맵 에디터에서 확인 후 변경할 것 */
-    this.SetResources = function(player, setto, num, resource) {
-        return "\tSet Resources(\"" + player + "\", " + setto + ", " + num + ", " + resource + ");\n";
+    
+    this.RemoveUnitAtLocation = function(player, unit, num, location) {
+        this.actionLineCount++;
+        return "\tRemove Unit At Location(\"" + player + "\", \"" + unit + "\", " + num + ", \"" + location + "\");\n";
+    }
+    /*
+    this.SetInvincibility = function(player, unit, location, state) {
+        this.actionLineCount++;
+        return "\tSet Invincibility(\"" + player + "\", \"" + unit + "\", \"" + location + "\", " + state + ");\n";
+    }
+    */
+    this.SetResources = function(player, modify, num, resource) {
+        this.actionLineCount++;
+        return "\tSet Resources(\"" + player + "\", " + modify + ", " + num + ", " + resource + ");\n";
     }
     
     this.Wait = function(duration) {
+        this.actionLineCount++;
         return "\tWait(" + duration + ");\n";
     }
 }


### PR DESCRIPTION
패턴 객체를 TE 트리거로 변환하는 기능을 구현하였으며, 다수 턴, 한 턴 내 다수 폭탄, 장애물 설치/제거 에 대한 테스틀 마쳤다. 자세한 내용은 아래 및 코드 참조

0.1.1v - 2020.03.18
 - 0.1.1v 은 TE 트리거 변환만 지원한다.
 - getPatternTETriggerText()를 호출하여 BoundPattern 객체를 TE 트리거 코드로(String) 반환한다.
 - 플레이어는 Player7, 조건은  Switch15와 1 이상의 미네랄로 고정되어있다. 데스값 제어는 아직 지원하지 않는다.
 - TE 에서 취급하는 문자열 상수들이 정의되어 있다.
 - TETextCreator 객체를 통해 TE 트리거 함수를 호출하듯 트리거 코드를 작성할 수 있다.
 - TE 함수를 호출할 때는 아래와 같은 순서대로 작성해야 올바른 트리거 코드를 얻을 수 있다.
   < Trigger() - Conditions() - {조건들} - Actions() - {액션들} - TriggerEnd() >
 - 또한 conditionLineCount와 actionLineCount가 최대치를 넘지 않도록 유의하여 작성하여야 한다.
 - 0.1.1v 에서는 구현하면서 꼭 필요했던 상수들과 함수들만 추가하였으나 그 외의 것이 필요하다면 TE와 동일한 양식으로 추가하면 된다.
 - 기본 기능 테스트는 전부 마쳤지만 그 외 많은 테스트를 수행하지 못했기에 문제가 발생할 여지가 있다.