### PR TITLE
Wait 대신 EUD터보 데스트리거를 사용하는 옵션 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,6 +319,10 @@
                     <label for="hyperTriggerCheckBox">터보 트리거를 포함합니다.</label>
                 </div>
                 <div class="short-interval">
+                    <input id="eudTurboCheckBox" type="checkbox" />
+                    <label for="eudTurboCheckBox">EUD터보 트리거를 포함합니다.</label>
+                </div>
+                <div class="short-interval">
                     <input id="deathTimerCheckBox" type="checkbox" />
                     <label for="deathTimerCheckBox">웨잇 대신 EUD터보 데스타이머를 사용합니다 (beta)</label>
                 </div>

--- a/index.html
+++ b/index.html
@@ -318,6 +318,10 @@
                     <input id="hyperTriggerCheckBox" type="checkbox" checked />
                     <label for="hyperTriggerCheckBox">터보 트리거를 포함합니다.</label>
                 </div>
+                <div class="short-interval">
+                    <input id="deathTimerCheckBox" type="checkbox" checked />
+                    <label for="deathTimerCheckBox">웨잇 대신 EUD터보 데스타이머를 사용합니다 (beta)</label>
+                </div>
                 <div>
                     <button id="extract">출력</button>
                 </div>

--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
                     <label for="hyperTriggerCheckBox">터보 트리거를 포함합니다.</label>
                 </div>
                 <div class="short-interval">
-                    <input id="deathTimerCheckBox" type="checkbox" checked />
+                    <input id="deathTimerCheckBox" type="checkbox" />
                     <label for="deathTimerCheckBox">웨잇 대신 EUD터보 데스타이머를 사용합니다 (beta)</label>
                 </div>
                 <div>

--- a/src/controller/header_elements.js
+++ b/src/controller/header_elements.js
@@ -448,6 +448,14 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
     $deathTimerCheckBox.on("change", function() {
         Log.debug('$deathTimerCheckBox.on("change")');
         let useDeathTimer = $(this).is(":checked");
+        if (useDeathTimer) {
+            // DeathTimer는 하이퍼트리거 대신 EUD터보트리거를 사용해야 합니다.
+            $hyperTriggerCheckBox.prop("checked", false);
+            $hyperTriggerCheckBox.prop("disabled", true);
+            triggerSettings.includeHyperTrigger = false;
+        } else {
+            $hyperTriggerCheckBox.prop("disabled", false);
+        }
         triggerSettings.useDeathTimer = useDeathTimer;
         Log.debug("triggerSettings.useDeathTimer : " + triggerSettings.useDeathTimer);
     });

--- a/src/controller/header_elements.js
+++ b/src/controller/header_elements.js
@@ -128,6 +128,8 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
     var $levelStartConditionCheckBox = $dialog.find("#levelStartConditionCheckBox");
     var $reviveConditionCheckBox = $dialog.find("#reviveConditionCheckBox");
     var $hyperTriggerCheckBox = $dialog.find("#hyperTriggerCheckBox");
+    var $deathTimerCheckBox = $dialog.find("#deathTimerCheckBox");
+
     var $extractButton = $dialog.find("#extract");
     var triggerSettings = {};
 
@@ -165,6 +167,7 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
         if (!triggerSettings.includeLevelStartCondition) $levelStartConditionCheckBox.prop("checked", false);
         if (!triggerSettings.includeReviveCondition) $reviveConditionCheckBox.prop("checked", false);
         if (!triggerSettings.includeHyperTrigger) $hyperTriggerCheckBox.prop("checked", false);
+        if (!triggerSettings.useDeathTimer) $deathTimerCheckBox.prop("checked", false);
     }
     else {
         // 트리거 세팅 초기화
@@ -193,6 +196,7 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
         triggerSettings.includeLevelStartCondition = $levelStartConditionCheckBox.is(":checked");
         triggerSettings.includeReviveCondition = $reviveConditionCheckBox.is(":checked");
         triggerSettings.includeHyperTrigger = $hyperTriggerCheckBox.is(":checked");
+        triggerSettings.useDeathTimer = $deathTimerCheckBox.is(":checked");
         
         Project.triggerSettings = triggerSettings;
     }
@@ -441,6 +445,13 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
         Log.debug("triggerSettings.includeHyperTrigger : " + triggerSettings.includeHyperTrigger);
     });
 
+    $deathTimerCheckBox.on("change", function() {
+        Log.debug('$deathTimerCheckBox.on("change")');
+        let useDeathTimer = $(this).is(":checked");
+        triggerSettings.useDeathTimer = useDeathTimer;
+        Log.debug("triggerSettings.useDeathTimer : " + triggerSettings.useDeathTimer);
+    });
+
     // 출력 이벤트 처리
     $extractButton.on("click", function() {
         if (triggerSettings.mapName === "" || !triggerSettings.mapName) {
@@ -535,7 +546,7 @@ HeaderElements.extractTrigger = function(triggerSettings) {
         if (result) triggerText += result;
     }
     
-    result = TriggerHandler.parsePatternList(editorType, patternList, bombPlayer, patternConditionUnit, turnConditionUnit);
+    result = TriggerHandler.parsePatternList(editorType, patternList, bombPlayer, patternConditionUnit, turnConditionUnit, triggerSettings.useDeathTimer);
     if (result) triggerText += result;
     
     if (triggerSettings.includeHyperTrigger) {

--- a/src/controller/header_elements.js
+++ b/src/controller/header_elements.js
@@ -128,6 +128,7 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
     var $levelStartConditionCheckBox = $dialog.find("#levelStartConditionCheckBox");
     var $reviveConditionCheckBox = $dialog.find("#reviveConditionCheckBox");
     var $hyperTriggerCheckBox = $dialog.find("#hyperTriggerCheckBox");
+    var $eudTurboCheckBox = $dialog.find("#eudTurboCheckBox");
     var $deathTimerCheckBox = $dialog.find("#deathTimerCheckBox");
 
     var $extractButton = $dialog.find("#extract");
@@ -167,7 +168,8 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
         if (!triggerSettings.includeLevelStartCondition) $levelStartConditionCheckBox.prop("checked", false);
         if (!triggerSettings.includeReviveCondition) $reviveConditionCheckBox.prop("checked", false);
         if (!triggerSettings.includeHyperTrigger) $hyperTriggerCheckBox.prop("checked", false);
-        if (!triggerSettings.useDeathTimer) $deathTimerCheckBox.prop("checked", false);
+        if (triggerSettings.includeEUDTurbo) $eudTurboCheckBox.prop("checked", true);
+        if (triggerSettings.useDeathTimer) $deathTimerCheckBox.prop("checked", true);
     }
     else {
         // 트리거 세팅 초기화
@@ -196,6 +198,7 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
         triggerSettings.includeLevelStartCondition = $levelStartConditionCheckBox.is(":checked");
         triggerSettings.includeReviveCondition = $reviveConditionCheckBox.is(":checked");
         triggerSettings.includeHyperTrigger = $hyperTriggerCheckBox.is(":checked");
+        triggerSettings.includeEUDTurbo = $eudTurboCheckBox.is(":checked");
         triggerSettings.useDeathTimer = $deathTimerCheckBox.is(":checked");
         
         Project.triggerSettings = triggerSettings;
@@ -441,8 +444,23 @@ HeaderElements.addTrigExtDialogEventListeners = function() {
     $hyperTriggerCheckBox.on("change", function() {
         Log.debug('$hyperTriggerCheckBox.on("change")');
         let includeHyperTrigger = $(this).is(":checked");
+        if (includeHyperTrigger) {
+            $eudTurboCheckBox.prop("checked", false);
+            triggerSettings.includeEUDTurbo = false;
+        }
         triggerSettings.includeHyperTrigger = includeHyperTrigger;
         Log.debug("triggerSettings.includeHyperTrigger : " + triggerSettings.includeHyperTrigger);
+    });
+
+    $eudTurboCheckBox.on("change", function() {
+        Log.debug('$eudTurboCheckBox.on("change")');
+        let includeEUDTurbo = $(this).is(":checked");
+        if (includeEUDTurbo) {
+            $hyperTriggerCheckBox.prop("checked", false);
+            triggerSettings.includeHyperTrigger = false;
+        }
+        triggerSettings.includeEUDTurbo = includeEUDTurbo;
+        Log.debug("triggerSettings.includeEUDTurbo : " + triggerSettings.includeEUDTurbo);
     });
 
     $deathTimerCheckBox.on("change", function() {
@@ -559,6 +577,11 @@ HeaderElements.extractTrigger = function(triggerSettings) {
     
     if (triggerSettings.includeHyperTrigger) {
         result = TriggerHandler.getHyperTriggers(editorType);
+        if (result) triggerText += result;
+    }
+
+    if (triggerSettings.includeEUDTurbo) {
+        result = TriggerHandler.getEUDTurbo(editorType);
         if (result) triggerText += result;
     }
 

--- a/src/trigedit.js
+++ b/src/trigedit.js
@@ -221,5 +221,10 @@ var TrigEdit = {
     Wait : function(duration) {
         this.actionLineCount++;
         return "\tWait(" + duration + ");\r\n";
+    },
+
+    EUDTurbo : function() {
+        this.actionLineCount++;
+        return "\tMemoryAddr(0x6509A0, Set To, 0);\r\n";
     }
 }

--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -37,6 +37,7 @@ const TH_TEXT_UNIT_REVIVE = "Unit Revive"; // 기존 : "유닛 부활"
 const TH_TEXT_DEFEAT = "Game Over";
 const TH_TEXT_VICTORY = "Victory";
 const TH_TEXT_HYPER_TRIGGER = "Hyper Triggers"; // 기존 : "터보 트리거"
+const TH_TEXT_EUD_TURBO = "Eud Turbo";
 const TH_TEXT_DEFEAT_CONDITION = "Defeat Condition"; // 기존 : "패배 조건"
 const TH_TEXT_VICTORY_CONDITION = "Victory Condition"; // 기존 : "승리 조건"
 const TH_TEXT_P12_KILL = "Unit Leftovers Delete"; // 기존 : "나간 유닛 삭제"
@@ -195,17 +196,6 @@ TriggerHandler.parsePattern = function(editorType, pattern, level, bombPlayer, p
         triggerTextList.push(TrigEdit.Actions());
         triggerTextList.push(TrigEdit.Comment(TH_TEXT_LEVEL + " " + level + " loop"));
         triggerTextList.push(TrigEdit.SetDeaths(bombPlayer, turnConditionUnit, TE_MODIFY_SET_TO, 0));
-        triggerTextList.push(TrigEdit.PreserveTrigger());
-        triggerTextList.push(TrigEdit.TriggerEnd());
-
-        // EUD 터보 트리거
-        // @TODO level 조건부와 함께 있다. 추후 광역으로 추가하는 걸 고려
-        triggerTextList.push(TrigEdit.TriggerStart(bombPlayer));
-        triggerTextList.push(TrigEdit.Conditions());
-        triggerTextList.push(TrigEdit.Deaths(bombPlayer, patternConditionUnit, TE_QUANTITYMOD_EXACTLY, level));
-        triggerTextList.push(TrigEdit.Actions());
-        triggerTextList.push(TrigEdit.Comment(TH_TEXT_LEVEL + " " + level + " eudturbo"));
-        triggerTextList.push(TrigEdit.EUDTurbo());
         triggerTextList.push(TrigEdit.PreserveTrigger());
         triggerTextList.push(TrigEdit.TriggerEnd());
 
@@ -569,6 +559,21 @@ TriggerHandler.getHyperTriggers = function(editorType) {
 
     return triggerText;
 };
+
+TriggerHandler.getEUDTurbo = function(editorType) {
+    const triggerTextList = [];
+
+    triggerTextList.push(TrigEdit.TriggerStart(TE_PLAYER_ALL));
+    triggerTextList.push(TrigEdit.Conditions());
+    triggerTextList.push(TrigEdit.Always());
+    triggerTextList.push(TrigEdit.Actions());
+    triggerTextList.push(TrigEdit.Comment(TH_TEXT_EUD_TURBO));
+    triggerTextList.push(TrigEdit.EUDTurbo());
+    triggerTextList.push(TrigEdit.PreserveTrigger());
+    triggerTextList.push(TrigEdit.TriggerEnd());
+
+    return triggerTextList.join("");
+}
 
 var isValidBombPlayer = function(bombPlayer) {
     // 폭탄 트리거용 플레이어 체크

--- a/src/trigger_handler.js
+++ b/src/trigger_handler.js
@@ -164,8 +164,12 @@ TriggerHandler.parsePattern = function(editorType, pattern, level, bombPlayer, p
                 curIndex += packedActionCnt;
             }
 
-            nextTimer += Math.floor(turn.wait / 42);
+            // wait 트리거 기준과 작동이 똑같도록
+            nextTimer += Math.floor((turn.wait || 42) / 42) + 1;
         });
+
+        // wait 트리거 기준과 작동이 똑같도록 마지막 턴 84ms 추가
+        nextTimer += 2;
 
         // Comment 작성
         const totalTime = nextTimer;


### PR DESCRIPTION
### 배경

wait대신 데스트리거를 쓰면 여러가지 장점이 있습니다.

1. wait꼬임이 일어나지 않습니다. 브금 트리거를 데스트리거로 구현할 시 깔끔한 구성 가능해집니다.
2. 패턴 내 턴마다 액션 수 제한에 대한 제약이 없습니다. 같은 조건부 아래에서 수행되는 모든 트리거들이 같이 수행됩니다.

### 구현 상세

**트리거 추출 옵션 수정**

* 폭탄 트리거에 EUD터보 데스 트리거를 사용하는 옵션 추가
* EUD 터보를 포함시키는 옵션 추가

### 스크린샷

![image](https://user-images.githubusercontent.com/10972723/97085198-ea5e9e00-1656-11eb-9e2e-1c38e6f13ea1.png)

* 주석의 뒷부분은 `[ 현재 프레임# / 전체 프레임 수 ]` 를 의미함.
* 데스 값이 점차 증가하며, 해당 데스값 상태일 때의 프레임에 해당 트리거가 실행 됨. `loop`류 주석이 달린 트리거가 해당 부분을 담당
